### PR TITLE
Projeyi analiz et

### DIFF
--- a/ustam_mobile_app/lib/core/router/app_router.dart
+++ b/ustam_mobile_app/lib/core/router/app_router.dart
@@ -32,7 +32,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       // Auth Routes
       GoRoute(
         path: '/login',
-        builder: (context, state) => const LoginScreen(),
+        builder: (context, state) => const LoginScreen(userType: 'customer'),
       ),
       GoRoute(
         path: '/register',

--- a/ustam_mobile_app/lib/features/dashboard/screens/customer_dashboard.dart
+++ b/ustam_mobile_app/lib/features/dashboard/screens/customer_dashboard.dart
@@ -39,6 +39,7 @@ class _CustomerDashboardState extends ConsumerState<CustomerDashboard> {
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(20),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Welcome Section
@@ -212,7 +213,7 @@ class _CustomerDashboardState extends ConsumerState<CustomerDashboard> {
               icon: Icons.build,
             ),
             
-            const SizedBox(height: 120), // Reduced bottom padding for navigation
+            const SizedBox(height: 100), // Optimized bottom padding for navigation
           ],
         ),
       ),
@@ -294,6 +295,7 @@ class _CustomerDashboardState extends ConsumerState<CustomerDashboard> {
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
+              mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Container(
@@ -373,6 +375,7 @@ class _CustomerDashboardState extends ConsumerState<CustomerDashboard> {
           const SizedBox(width: 16),
           Expanded(
             child: Column(
+              mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
@@ -395,6 +398,7 @@ class _CustomerDashboardState extends ConsumerState<CustomerDashboard> {
             ),
           ),
           Column(
+            mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text(
@@ -467,6 +471,7 @@ class _CustomerDashboardState extends ConsumerState<CustomerDashboard> {
           const SizedBox(width: 16),
           Expanded(
             child: Column(
+              mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(

--- a/ustam_mobile_app/lib/features/messages/screens/messages_screen.dart
+++ b/ustam_mobile_app/lib/features/messages/screens/messages_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../auth/providers/auth_provider.dart';
 
 class MessagesScreen extends ConsumerStatefulWidget {
   const MessagesScreen({super.key});
@@ -83,7 +84,13 @@ class _MessagesScreenState extends ConsumerState<MessagesScreen> {
           });
           switch (index) {
             case 0:
-              Navigator.pushReplacementNamed(context, '/customer-dashboard');
+              // Navigate to appropriate dashboard based on user type
+              final authState = ref.read(authProvider);
+              if (authState.user?['user_type'] == 'craftsman') {
+                Navigator.pushReplacementNamed(context, '/craftsman-dashboard');
+              } else {
+                Navigator.pushReplacementNamed(context, '/customer-dashboard');
+              }
               break;
             case 1:
               Navigator.pushReplacementNamed(context, '/search');

--- a/ustam_mobile_app/pubspec.yaml
+++ b/ustam_mobile_app/pubspec.yaml
@@ -66,8 +66,8 @@ dependencies:
   lottie: ^3.1.2
   
   # Forms & Validation
-  flutter_form_builder: ^10.1.0
-  form_builder_validators: ^11.0.0
+  flutter_form_builder: ^9.4.1
+  form_builder_validators: ^10.0.1
   
   # Image & Media
   image_picker: ^1.1.2
@@ -84,7 +84,7 @@ dependencies:
   flutter_local_notifications: ^17.2.2
   
   # Utils
-  intl: ^0.20.2
+  intl: ^0.19.0
   url_launcher: ^6.3.0
   share_plus: ^10.0.2
   


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes navigation to the wrong dashboard for craftsmen and resolves RenderFlex overflow errors on the customer dashboard.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The navigation bug in the messages screen's bottom navigation was due to a hardcoded route to the customer dashboard, which now dynamically routes based on the user's account type. RenderFlex overflow errors were resolved by applying `mainAxisSize: MainAxisSize.min` to relevant `Column` widgets and optimizing bottom padding, ensuring content fits within its bounds. Dependency versions were also adjusted to resolve conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bad3cdb-d970-4f6c-9ec1-ddb46457f4cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bad3cdb-d970-4f6c-9ec1-ddb46457f4cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>